### PR TITLE
fixed ECIP1099 check for ETH

### DIFF
--- a/etchash.go
+++ b/etchash.go
@@ -510,9 +510,12 @@ func (l *Light) getCache(blockNum uint64) *cache {
 		var nextEpoch = epoch + 1
 		var nextEpochLength = epochLength
 		var nextEpochBlock = nextEpoch * epochLength
-		if nextEpochBlock == *l.ecip1099FBlock && epochLength == epochLengthDefault {
-			nextEpoch = nextEpoch / 2
-			nextEpochLength = epochLengthECIP1099
+
+		if l.ecip1099FBlock != nil {
+			if nextEpochBlock == *l.ecip1099FBlock && epochLength == epochLengthDefault {
+				nextEpoch = nextEpoch / 2
+				nextEpochLength = epochLengthECIP1099
+			}
 		}
 
 		// If we just used up the future cache, or need a refresh, regenerate


### PR DESCRIPTION
In line 513 of `ethash.go` it *always* checks the value of the `ecip1099FBlock`, though when this is used for `ethash` that is explicitly set as `nil`. Thus it ends up segfaulting with the usage of `ethash`.

This is a simple fix to check whether or not `ecip1099FBlock` is set before checking the pointer's value.